### PR TITLE
fix compatibility with Android plugin 0.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     groovy localGroovy()
     compile gradleApi()
     compile 'com.squareup.spoon:spoon-runner:1.1.1+'
-    compile 'com.android.tools.build:gradle:0.9.+'
+    compile 'com.android.tools.build:gradle:0.10.+'
 }
 
 task sourceJar(type: Jar) {

--- a/src/main/groovy/de/felixschulze/gradle/SpoonPlugin.groovy
+++ b/src/main/groovy/de/felixschulze/gradle/SpoonPlugin.groovy
@@ -75,7 +75,7 @@ class SpoonPlugin implements Plugin<Project> {
         task.instrumentationApk = variant.outputFile
         task.setTestSize(testSize)
         task.outputs.upToDateWhen { false }
-        task.sdkDir = project.getPlugins().findPlugin(AppPlugin).getSdkDirectory()
+        task.sdkDir = project.android.sdkDirectory
         task.dependsOn variant.assemble, variant.testedVariant.assemble
         task.testClassName = project.hasProperty('spoonTestClass') ? project.property('spoonTestClass') : ""
         task.testMethodName = project.hasProperty('spoonTestMethod') ? project.property('spoonTestMethod') : ""


### PR DESCRIPTION
Fixes this error with the plugin 0.10.x

```
* Exception is:
    [... removed for brevity]
Caused by: org.codehaus.groovy.runtime.InvokerInvocationException: groovy.lang.MissingMethodException: No signature of method: com.android.build.gradle.AppPlugin.getSdkDirectory() is applicable for argument types: () values: []
    at org.gradle.listener.ClosureBackedMethodInvocationDispatch.dispatch(ClosureBackedMethodInvocationDispatch.java:40)
    at org.gradle.listener.ClosureBackedMethodInvocationDispatch.dispatch(ClosureBackedMethodInvocationDispatch.java:25)
    at org.gradle.listener.BroadcastDispatch.dispatch(BroadcastDispatch.java:79)
    at org.gradle.listener.BroadcastDispatch.dispatch(BroadcastDispatch.java:31)
    at org.gradle.messaging.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:93)
    at com.sun.proxy.$Proxy14.afterEvaluate(Unknown Source)
    at org.gradle.configuration.project.LifecycleProjectEvaluator.notifyAfterEvaluate(LifecycleProjectEvaluator.java:67)
    ... 49 more
Caused by: groovy.lang.MissingMethodException: No signature of method: com.android.build.gradle.AppPlugin.getSdkDirectory() is applicable for argument types: () values: []
    at de.felixschulze.gradle.SpoonPlugin.createTask(SpoonPlugin.groovy:78)
    at de.felixschulze.gradle.SpoonPlugin$_applyTasks_closure2.doCall(SpoonPlugin.groovy:56)
    at org.gradle.api.internal.ClosureBackedAction.execute(ClosureBackedAction.java:58)
    at org.gradle.api.internal.DefaultDomainObjectCollection.all(DefaultDomainObjectCollection.java:110)
    at org.gradle.api.internal.DefaultDomainObjectCollection.all(DefaultDomainObjectCollection.java:115)
    at org.gradle.api.DomainObjectCollection$all$0.call(Unknown Source)
    at de.felixschulze.gradle.SpoonPlugin.applyTasks(SpoonPlugin.groovy:55)
    at de.felixschulze.gradle.SpoonPlugin$_applyExtensions_closure1.doCall(SpoonPlugin.groovy:46)
    ... 56 more
```
